### PR TITLE
Fixes calculation of the execution time in CleanFromJson.java

### DIFF
--- a/src/org/fog/test/CleanFromJson.java
+++ b/src/org/fog/test/CleanFromJson.java
@@ -17,6 +17,7 @@ import org.fog.placement.Controller;
 import org.fog.placement.ModuleMapping;
 import org.fog.placement.ModulePlacementEdgewards;
 import org.fog.utils.JsonToTopology;
+import org.fog.utils.TimeKeeper;
 
 /**
  * Simulation setup for EEG Beam Tractor Game extracting physical topology 
@@ -55,6 +56,8 @@ public class CleanFromJson {
 			controller.submitApplication(application, 0, new ModulePlacementEdgewards(physicalTopology.getFogDevices(), 
 					physicalTopology.getSensors(), physicalTopology.getActuators(), 
 					application, ModuleMapping.createModuleMapping()));
+			
+			TimeKeeper.getInstance().setSimulationStartTime(Calendar.getInstance().getTimeInMillis());
 			
 			CloudSim.startSimulation();
 


### PR DESCRIPTION
Before the fix, setSimulationStartTime() was never called out and, therefore, SimulationStartTime was always set to 0. This resulted in incorrect calculation of Execution Time.
