### PR TITLE
Fix two bugs in the DCNSFog simulation

### DIFF
--- a/src/org/fog/test/perfeval/DCNSFog.java
+++ b/src/org/fog/test/perfeval/DCNSFog.java
@@ -124,7 +124,7 @@ public class DCNSFog {
 	}
 
 	private static FogDevice addArea(String id, int userId, String appId, int parentId){
-		FogDevice router = createFogDevice("d-"+id, 2800, 4000, 10000, 10000, 1, 0.0, 107.339, 83.4333);
+		FogDevice router = createFogDevice("d-"+id, 2800, 4000, 10000, 10000, 2, 0.0, 107.339, 83.4333);
 		fogDevices.add(router);
 		router.setUplinkLatency(2); // latency of connection between router and proxy server is 2 ms
 		for(int i=0;i<numOfCamerasPerArea;i++){
@@ -138,7 +138,7 @@ public class DCNSFog {
 	}
 	
 	private static FogDevice addCamera(String id, int userId, String appId, int parentId){
-		FogDevice camera = createFogDevice("m-"+id, 500, 1000, 10000, 10000, 3, 0, 87.53, 82.44);
+		FogDevice camera = createFogDevice("m-"+id, 1000, 1000, 10000, 10000, 3, 0, 87.53, 82.44);
 		camera.setParentId(parentId);
 		Sensor sensor = new Sensor("s-"+id, "CAMERA", userId, appId, new DeterministicDistribution(5)); // inter-transmission time of camera (sensor) follows a deterministic distribution
 		sensors.add(sensor);


### PR DESCRIPTION
This PR fixes:
* the layer of the router in the infrastructure hierarchy (should be on layer 2 since the cloud is on layer 0 and the ISP gateway (proxy-server) on layer 1)
* the mips for a smart camera (set to 1000 because all application modules created have a mips requirement from 1000)